### PR TITLE
rm unused value 'labelSize'

### DIFF
--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -86,8 +86,6 @@ open class ChartLabelDrawer: ChartContextDrawer {
     }
 
     override open func draw(context: CGContext, chart: Chart) {
-        let labelSize = size
-        
         let labelX = screenLoc.x
         let labelY = screenLoc.y
         


### PR DESCRIPTION
This resolves the warning: "initialization of immutable value 'labelSize' was never used; consider replacing with assignment to '_' or removing it"