### PR TITLE
Add explicit UIKit and CoreGraphics imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
      name: "SwiftCharts",
      platforms: [
-         .iOS(.v8)
+         .iOS(.v9)
      ],
      products: [
          .library(name: "SwiftCharts", type: .dynamic, targets: ["SwiftCharts"])

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
          .iOS(.v8)
      ],
      products: [
-         .library(name: "SwiftCharts", targets: ["SwiftCharts"])
+         .library(name: "SwiftCharts", type: .dynamic, targets: ["SwiftCharts"])
      ],
      targets: [
         .target(

--- a/SwiftCharts/Axis/ChartAxisLabelsConflictSolverMoveUpDown.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsConflictSolverMoveUpDown.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 /// Solves frame overlaps by moving drawers up and down by half of the height of their frames. Assumes being used for y axis, which currently supports only 1 label per axis value.
 open class ChartAxisLabelsConflictSolverMoveUpDown: ChartAxisLabelsConflictSolver {

--- a/SwiftCharts/Axis/ChartAxisLabelsGenerator.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGenerator.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 /// Generates labels for an axis value. Note: Supports only one label per axis value (1 element array)
 public protocol ChartAxisLabelsGenerator {

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorBase.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorBase.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 /// Needed for common stored properties which are not possible in the extension (without workarounds)
 open class ChartAxisLabelsGeneratorBase: ChartAxisLabelsGenerator {

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorBasic.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorBasic.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Generates a single unformatted label for scalar
 open class ChartAxisLabelsGeneratorBasic: ChartAxisLabelsGeneratorBase {

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorFixed.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorFixed.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 open class ChartAxisLabelsGeneratorFixed: ChartAxisLabelsGeneratorBase {
     

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorFunc.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorFunc.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Label generator that delegates to a closure, for greater flexibility
 open class ChartAxisLabelsGeneratorFunc: ChartAxisLabelsGeneratorBase {

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorNumber.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorNumber.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Generates a single formatted number for scalar
 open class ChartAxisLabelsGeneratorNumber: ChartAxisLabelsGeneratorBase {

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorNumberSuffix.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorNumberSuffix.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public enum ChartAxisLabelNumberSuffixUnit {
     case k, m, g, t, p, e

--- a/SwiftCharts/Axis/ChartAxisValuesGeneratorXDividers.swift
+++ b/SwiftCharts/Axis/ChartAxisValuesGeneratorXDividers.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 open class ChartAxisValuesGeneratorXDividers: ChartAxisGeneratorMultiplier {
     

--- a/SwiftCharts/Chart.swift
+++ b/SwiftCharts/Chart.swift
@@ -677,10 +677,10 @@ open class ChartView: UIView, UIGestureRecognizerDelegate {
             
             let location = sender.location(in: self)
             
-            var deltaX = lastPanTranslation.map{trans.x - $0.x} ?? trans.x
+            let deltaX = lastPanTranslation.map{trans.x - $0.x} ?? trans.x
             let deltaY = lastPanTranslation.map{trans.y - $0.y} ?? trans.y
 
-            var (finalDeltaX, finalDeltaY) = finalPanDelta(deltaX: deltaX, deltaY: deltaY)
+            let (finalDeltaX, finalDeltaY) = finalPanDelta(deltaX: deltaX, deltaY: deltaY)
             
             lastPanTranslation = trans
             
@@ -690,7 +690,7 @@ open class ChartView: UIView, UIGestureRecognizerDelegate {
 
         case .ended:
             
-            guard let view = sender.view, let chart = chart else {print("No view or chart"); return}
+            guard let _ = sender.view, let chart = chart else {print("No view or chart"); return}
             
             
             let velocityX = sender.velocity(in: sender.view).x

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -86,8 +86,6 @@ open class ChartLabelDrawer: ChartContextDrawer {
     }
 
     override open func draw(context: CGContext, chart: Chart) {
-        let labelSize = size
-        
         let labelX = screenLoc.x
         let labelY = screenLoc.y
         

--- a/SwiftCharts/Utils/Operators.swift
+++ b/SwiftCharts/Utils/Operators.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 infix operator =~ : ComparisonPrecedence
 


### PR DESCRIPTION
This PR fixes an issue with using SwiftCharts from another package. 

I am developing another package with SwiftCharts as a dependency, like this:
```
dependencies: [
        .package(url: "https://github.com/i-schuetz/SwiftCharts.git", .branch("master"))
    ],
```

When building this package, Xcode does not appear to include the "SwiftCharts/Supporting Files/SwiftCharts.h" file, and so all the references to CGFloat, UIFont, etc are unresolved. Making the import of UIKit or CoreGraphics explicit solves this issue.